### PR TITLE
DC-79 Use Jinja in DVC Docstring arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ The configuration file format is JSON
     	"dvc_cmd_root_dir": "[path_to_the_dvc_cmd_directory]"
     	}
     "ignore_keys: ["keywords", "to", "ignore"],
-    'dvc_var_python_cmd_path': 'MLV_PY_CMD_PATH_CUSTOM',
-    'dvc_var_python_cmd_name': 'MLV_PY_CMD_NAME_CUSTOM',
+    "dvc_var_python_cmd_path": "MLV_PY_CMD_PATH_CUSTOM",
+    "dvc_var_python_cmd_name": "MLV_PY_CMD_NAME_CUSTOM",
+    "docstring_conf": "./docstring_conf.yml" 
     }
 
 All given path must be relative to the **working directory**
@@ -92,6 +93,9 @@ can be used in **dvc-cmd** Docstring parameter. They respectively correspond to 
 file path, the file name and the variable holding the **DVC** default meta file name. Default values are 'MLV_PY_CMD_PATH',
  'MLV_PY_CMD_NAME' and 'MLV_DVC_META_FILENAME'. (See DVC Command/Complex cases section for usage) 
 
+- *docstring_conf*: the path to the docstring configuration used for Jinja templating (see DVC templating section). 
+This parameter is not mandatory.
+
 
 Jupyter Notebook syntax
 -----------------------
@@ -107,10 +111,10 @@ Avoid using relative paths in your Jupyter Notebook because they are relative to
 the notebook location which is not the same when it will be converted to a script.
 
 
-### Parameterize
+### Python Script Parameters
 
-Parameter can be declared in the **Jupyter Notebook** using basic Docstring syntax.
-This parameter description is used to generate configurable and executable python scripts.
+Parameters can be declared in the **Jupyter Notebook** using basic Docstring syntax.
+This parameters description is used to generate configurable and executable python scripts.
 
 Parameters declaration in **Jupyter Notebook**:
 
@@ -229,6 +233,34 @@ The variable $MLV_DVC_META_FILENAME contains the default name of the **DVC** met
         "$MLV_PY_CMD_PATH -m train --out ./out_train.csv && \
         $MLV_PY_CMD_PATH -m test --out ./out_test.csv"    
     popd
+
+
+### DVC templating
+
+It is possible to use Jinja2 template in DVC Docstring part. For example, it can be useful to declare all 
+steps dependencies, outputs and extra parameters.
+
+Example:
+
+    # Docstring in Jupyter notebook    
+    """
+    [...]
+    :dvc-in: {{ conf.train_data_file_path }}    
+    :dvc-out: {{ conf.model_file_path }}
+    :dvc-extra: --rate {{ conf.rate }}
+    """
+    
+    # Docstring configuration file (Yaml format): ./dc_conf.yml
+    
+    train_data_file_path: ./data/trainset.csv
+    model_file_path: ./data/model.pkl
+    rate: 45
+    
+    # DVC command generation
+    gen_dvc -i ./python_script.py --docstring-conf ./dc_conf.yml
+    
+The *Docstring configuration file* can be provided through the main configuration or using **--docstring-conf**
+argument. This feature is only available for **gen_dvc** command.
 
 
 ### Discard cell

--- a/mlvtools/cmd.py
+++ b/mlvtools/cmd.py
@@ -39,6 +39,11 @@ class ArgumentBuilder:
                                  help='Force output overwrite.')
         return self
 
+    def add_docstring_conf(self) -> 'ArgumentBuilder':
+        self.parser.add_argument('--docstring-conf', type=str,
+                                 help='User configuration used for docstring templating')
+        return self
+
     def add_argument(self, *args, **kwargs) -> 'ArgumentBuilder':
         self.parser.add_argument(*args, **kwargs)
         return self

--- a/mlvtools/conf/conf.py
+++ b/mlvtools/conf/conf.py
@@ -7,7 +7,6 @@ from typing import List
 
 import yaml
 from pydantic import BaseModel, validator, ValidationError
-from yaml import YAMLError
 
 from mlvtools.exception import MlVToolConfException, MlVToolException
 from mlvtools.helper import to_script_name, to_dvc_cmd_name, get_git_top_dir
@@ -106,7 +105,7 @@ def load_docstring_conf(docstring_conf_path: str) -> dict:
     try:
         with open(docstring_conf_path, 'r') as fd:
             return yaml.load(fd)
-    except YAMLError as e:
+    except yaml.YAMLError as e:
         raise MlVToolConfException(f'Cannot load docstring conf {docstring_conf_path}. Format error {e}.') from e
     except IOError as e:
         raise MlVToolConfException(f'Cannot load file {docstring_conf_path}. IOError {e}') from e

--- a/mlvtools/conf/conf.py
+++ b/mlvtools/conf/conf.py
@@ -5,7 +5,9 @@ from json import JSONDecodeError
 from os.path import join, exists, basename, dirname
 from typing import List
 
+import yaml
 from pydantic import BaseModel, validator, ValidationError
+from yaml import YAMLError
 
 from mlvtools.exception import MlVToolConfException, MlVToolException
 from mlvtools.helper import to_script_name, to_dvc_cmd_name, get_git_top_dir
@@ -27,6 +29,7 @@ class MlVToolConf(BaseModel):
     dvc_var_python_cmd_path: str = 'MLV_PY_CMD_PATH'
     dvc_var_python_cmd_name: str = 'MLV_PY_CMD_NAME'
     dvc_var_meta_filename: str = 'MLV_DVC_META_FILENAME'
+    docstring_conf: str = None
 
     @validator('dvc_var_python_cmd_path', 'dvc_var_python_cmd_name', 'dvc_var_meta_filename')
     def is_valid_var_name(cls, value, values, config, field):
@@ -96,3 +99,14 @@ def get_work_directory(input_path: str) -> str:
 
 def get_conf_file_default_path(work_dir: str) -> str:
     return join(work_dir, DEFAULT_CONF_FILENAME)
+
+
+def load_docstring_conf(docstring_conf_path: str) -> dict:
+    """ Load a Yaml format docstring configuration """
+    try:
+        with open(docstring_conf_path, 'r') as fd:
+            return yaml.load(fd)
+    except YAMLError as e:
+        raise MlVToolConfException(f'Cannot load docstring conf {docstring_conf_path}. Format error {e}.') from e
+    except IOError as e:
+        raise MlVToolConfException(f'Cannot load file {docstring_conf_path}. IOError {e}') from e

--- a/mlvtools/docstring_helpers/extract.py
+++ b/mlvtools/docstring_helpers/extract.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 from docstring_parser import parse as dc_parse
 
+from mlvtools.docstring_helpers.parse import resolve_docstring
 from mlvtools.exception import MlVToolException
 
 
@@ -25,7 +26,7 @@ DocstringInfo = namedtuple('DocstringInfo',
                            ('method_name', 'docstring', 'repr', 'file_path'))
 
 
-def extract_docstring_from_file(input_path: str) -> DocstringInfo:
+def extract_docstring_from_file(input_path: str, docstring_conf: dict = None) -> DocstringInfo:
     """
         Extract method docstring information (docstring, method_name, input_path)
         The provided python script must have one and only one method
@@ -44,6 +45,8 @@ def extract_docstring_from_file(input_path: str) -> DocstringInfo:
         if isinstance(node, ast.FunctionDef):
             method_name = node.name
             docstring_str = ast.get_docstring(node)
+            if docstring_conf:
+                docstring_str = resolve_docstring(docstring_str, docstring_conf)
             docstring = dc_parse(docstring_str)
             break
     else:

--- a/mlvtools/docstring_helpers/parse.py
+++ b/mlvtools/docstring_helpers/parse.py
@@ -1,8 +1,10 @@
 from collections import namedtuple
 from typing import Dict, List, Optional
 
+import jinja2
 from docstring_parser import parse as dc_parse
 from docstring_parser.parser import Docstring, ParseError
+from jinja2 import Environment
 
 from mlvtools.exception import MlVToolException
 
@@ -188,3 +190,13 @@ def parse_docstring(docstring_str: str) -> Docstring:
     except ParseError as e:
         raise MlVToolException(f'Docstring format error. {e}') from e
     return docstring
+
+
+def resolve_docstring(docstring: str, docstring_conf: dict) -> str:
+    """
+        Use jinja to resolve docstring template using user custom configuration
+    """
+    try:
+        return Environment().from_string(docstring).render(conf=docstring_conf)
+    except jinja2.exceptions.TemplateError as e:
+        raise MlVToolException(f'Cannot resolve docstring using Jinja, {e}') from e

--- a/mlvtools/docstring_helpers/parse.py
+++ b/mlvtools/docstring_helpers/parse.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 import jinja2
 from docstring_parser import parse as dc_parse
 from docstring_parser.parser import Docstring, ParseError
-from jinja2 import Environment
 
 from mlvtools.exception import MlVToolException
 
@@ -197,6 +196,6 @@ def resolve_docstring(docstring: str, docstring_conf: dict) -> str:
         Use jinja to resolve docstring template using user custom configuration
     """
     try:
-        return Environment().from_string(docstring).render(conf=docstring_conf)
+        return jinja2.Environment().from_string(docstring).render(conf=docstring_conf)
     except jinja2.exceptions.TemplateError as e:
         raise MlVToolException(f'Cannot resolve docstring using Jinja, {e}') from e

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     Jinja2==2.10
     nbconvert==5.3.1
     pydantic==0.13
+    PyYAML
 [options.extras_require]
 dev =
     pytest==3.7.2

--- a/tests/conf/test_conf.py
+++ b/tests/conf/test_conf.py
@@ -5,10 +5,11 @@ from os import makedirs
 from os.path import join
 
 import pytest
+from yaml import YAMLError
 
 from mlvtools.conf.conf import MlVToolConf, get_script_output_path, \
     get_dvc_cmd_output_path, get_conf_file_default_path, DEFAULT_CONF_FILENAME, get_work_directory, \
-    load_conf_or_default
+    load_conf_or_default, load_docstring_conf
 from mlvtools.exception import MlVToolConfException, MlVToolException
 from tests.helpers.utils import write_conf
 
@@ -20,7 +21,7 @@ def test_should_load_conf_file(work_dir):
     write_conf(work_dir=work_dir, conf_path=conf_file, ignore_keys=['# No effect', "# Ignore"],
                script_dir='./scripts', dvc_cmd_dir='./dvc_cmd',
                dvc_py_cmd_name='VAR_Name', dvc_py_cmd_path='var_PATh3',
-               dvc_meta_file_name='mETA_VAR_NaME')
+               dvc_meta_file_name='mETA_VAR_NaME', docstring_conf='./doc_conf.yml')
 
     conf = load_conf_or_default(conf_file, working_directory=work_dir)
 
@@ -31,6 +32,7 @@ def test_should_load_conf_file(work_dir):
     assert conf.dvc_var_python_cmd_path == 'var_PATh3'
     assert conf.dvc_var_python_cmd_name == 'VAR_Name'
     assert conf.dvc_var_meta_filename == 'mETA_VAR_NaME'
+    assert conf.docstring_conf == './doc_conf.yml'
 
     script_path = join(conf.path.python_script_root_dir, 'mlvtools_pipeline_part1.py')
     assert get_script_output_path('./data/Pipeline Part1.ipynb', conf) == join(work_dir, script_path)
@@ -135,3 +137,37 @@ def test_should_raise_if_input_file_does_not_exist():
     """
     with pytest.raises(MlVToolException):
         get_work_directory('./does_not_exit.ipynb')
+
+
+def test_should_load_docstring_configuration(work_dir):
+    """
+        Test load Yaml format docstring configuration
+    """
+    docstring_conf_path = join(work_dir, 'dc_conf.yml')
+    with open(docstring_conf_path, 'w') as fd:
+        fd.write('var1: ./ouptut_path.txt\nvar2: test')
+    dc_conf = load_docstring_conf(docstring_conf_path)
+    assert dc_conf == {'var1': './ouptut_path.txt',
+                       'var2': 'test'}
+
+
+def test_should_raise_if_docstring_configuration_invalid_yaml(work_dir):
+    """
+        Test should raise if docstring configuration Yaml format is invalid
+    """
+    docstring_conf_path = join(work_dir, 'dc_conf.yml')
+    with open(docstring_conf_path, 'w') as fd:
+        fd.write('t\n\t\thhh')
+    with pytest.raises(MlVToolConfException) as ex:
+        load_docstring_conf(docstring_conf_path)
+    assert isinstance(ex.value.__cause__, YAMLError)
+
+
+def test_should_raise_if_docstring_configuration_file_not_found(work_dir):
+    """
+        Test should raise if docstring configuration file not found
+    """
+    docstring_conf_path = join(work_dir, 'not_found.yml')
+    with pytest.raises(MlVToolConfException) as ex:
+        load_docstring_conf(docstring_conf_path)
+    assert isinstance(ex.value.__cause__, IOError)

--- a/tests/docstring/test_extract.py
+++ b/tests/docstring/test_extract.py
@@ -27,6 +27,19 @@ def test_should_extract_docstring_from_python_file(work_dir):
     assert docstring_info.docstring
 
 
+def test_should_extract_resolved_docstring(work_dir):
+    """Test jinja template is applied on extracted docstring"""
+    docstring = '""":dvc-out param-one: {{ conf.out_path }}"""'
+    docstring_file = join(work_dir, 'test_file')
+    with open(docstring_file, 'w') as fd:
+        fd.write('def my_method():\n')
+        fd.write(f'\t{docstring}\n')
+        fd.write('\tpass')
+    user_conf = {'out_path': 'path/to/other'}
+    docstring_info = extract_docstring_from_file(docstring_file, user_conf)
+    assert docstring_info.repr == ':dvc-out param-one: path/to/other'
+
+
 def test_should_raise_if_file_not_found():
     """
         Test docstring extraction handle file not found

--- a/tests/functional/gen_dvc/test_conf.py
+++ b/tests/functional/gen_dvc/test_conf.py
@@ -1,16 +1,24 @@
 from os.path import join, exists
 from typing import Tuple
 
+import yaml
+
 from mlvtools.conf.conf import DEFAULT_CONF_FILENAME
 from mlvtools.gen_dvc import MlScriptToCmd
 from tests.helpers.utils import write_conf, write_min_script
 
 
-def setup_with_conf(work_dir: str, conf_path: str) -> Tuple[str, str]:
+def write_docstring_conf(path: str, output_file: str):
+    with open(path, 'w') as fd:
+        yaml.dump({'out_file': output_file}, fd)
+
+
+def setup_with_conf(work_dir: str, conf_path: str = None, docstring_conf_path: str = None) -> Tuple[str, str]:
     write_conf(work_dir=work_dir, conf_path=conf_path, ignore_keys=['# Ignore'],
-               dvc_cmd_dir='./dvc_cmd')
+               dvc_cmd_dir='./dvc_cmd', docstring_conf=docstring_conf_path)
     script_path = join(work_dir, 'script_path.py')
-    write_min_script(script_path)
+    docstring = '"""\n:param out:\n:dvc-out out: {{ conf.out_file }}\n"""' if docstring_conf_path else None
+    write_min_script(script_path, docstring)
     return conf_path, script_path
 
 
@@ -28,6 +36,25 @@ def test_should_get_output_path_from_conf(work_dir):
     assert exists(dvc_cmd_path)
 
 
+def test_should_get_docstring_conf_from_main_conf(work_dir):
+    """
+        Test docstring template values are replaced with docstring conf provided in main conf file
+    """
+    conf_dc_conf_path = join(work_dir, 'conf_dc_path.yml')
+    write_docstring_conf(conf_dc_conf_path, './output_file_base.txt')
+    conf_path, script_path = setup_with_conf(work_dir, conf_path=join(work_dir, DEFAULT_CONF_FILENAME),
+                                             docstring_conf_path=conf_dc_conf_path)
+
+    dvc_cmd_path = join(work_dir, 'new_place_dvc')
+    arguments = ['-i', script_path, '--working-directory', work_dir, '--out-dvc-cmd', dvc_cmd_path]
+    MlScriptToCmd().run(*arguments)
+
+    # Assert docstring template value are replaced with the docstring conf content
+    with open(dvc_cmd_path, 'r') as fd:
+        content = fd.read()
+    assert './output_file_base.txt' in content
+
+
 def test_should_get_output_path_from_auto_detected_conf(work_dir):
     """
         Test commands are generated from python script using auto detected configuration
@@ -42,7 +69,7 @@ def test_should_get_output_path_from_auto_detected_conf(work_dir):
     assert exists(dvc_cmd_path)
 
 
-def test_should_overwrite_conf(work_dir):
+def test_should_overwrite_conf_for_path(work_dir):
     """
         Test output paths argument overwrite conf
     """
@@ -56,3 +83,27 @@ def test_should_overwrite_conf(work_dir):
     assert exists(arg_dvc_cmd_path)
     conf_dvc_cmd_path = join(work_dir, 'dvc_cmd', 'script_path_dvc')
     assert not exists(conf_dvc_cmd_path)
+
+
+def test_should_overwrite_conf_for_docstring_conf(work_dir):
+    """
+        Test main configuration is overwritten for docstring conf selection
+    """
+    conf_dc_conf_path = join(work_dir, 'conf_dc_path.yml')
+    write_docstring_conf(conf_dc_conf_path, './output_file_base.txt')
+    conf_path, script_path = setup_with_conf(work_dir, conf_path=join(work_dir, DEFAULT_CONF_FILENAME),
+                                             docstring_conf_path=conf_dc_conf_path)
+
+    new_dc_conf_path = join(work_dir, 'new_dc_path.yml')
+    write_docstring_conf(new_dc_conf_path, './output_file_overwritten.txt')
+
+    dvc_cmd_path = join(work_dir, 'new_place_dvc')
+    arguments = ['-i', script_path, '--working-directory', work_dir, '--docstring-conf', new_dc_conf_path,
+                 '--out-dvc-cmd', dvc_cmd_path]
+    MlScriptToCmd().run(*arguments)
+
+    # Assert docstring template value are replaced with the right conf content
+    with open(dvc_cmd_path, 'r') as fd:
+        content = fd.read()
+    assert './output_file_base.txt' not in content
+    assert './output_file_overwritten.txt' in content

--- a/tests/functional/ipynb_to_python/test_generated_content.py
+++ b/tests/functional/ipynb_to_python/test_generated_content.py
@@ -18,6 +18,7 @@ def generate_test_notebook(work_dir: str, notebook_name: str):
     docstring = '"""\n' \
                 ':param str subset: The kind of subset to generate.\n' \
                 ':param int rate:\n' \
+                ':dvc-out output_file: {{ conf.output_file }}\n' \
                 '"""\n'
     cells = [
 

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -27,7 +27,7 @@ def to_notebook_code_cell(cell_content: str) -> nbf.NotebookNode:
 def write_conf(work_dir: str, conf_path: str, ignore_keys: List[str] = None,
                script_dir: str = None, dvc_cmd_dir: str = None,
                dvc_py_cmd_path: str = None, dvc_py_cmd_name: str = None,
-               dvc_meta_file_name: str = None) -> dict:
+               dvc_meta_file_name: str = None, docstring_conf: str = None) -> dict:
     ignore_keys = ignore_keys or []
     script_dir = script_dir or join('script')
     dvc_cmd_dir = dvc_cmd_dir or join('cmd', 'dvc')
@@ -46,14 +46,17 @@ def write_conf(work_dir: str, conf_path: str, ignore_keys: List[str] = None,
         conf_data['dvc_var_python_cmd_path'] = dvc_py_cmd_path
     if dvc_meta_file_name:
         conf_data['dvc_var_meta_filename'] = dvc_meta_file_name
+    if docstring_conf:
+        conf_data['docstring_conf'] = docstring_conf
     with open(conf_path, 'w') as fd:
         json.dump(conf_data, fd)
     return conf_data
 
 
-def write_min_script(script_path: str):
+def write_min_script(script_path: str, docstring: str = None):
+    docstring = docstring or '""" A description """'
     python_script = 'def my_funct():\n' \
-                    '\t""" A description """\n' \
+                    f'\t{docstring}\n' \
                     '\tpass\n'
     with open(script_path, 'w') as fd:
         fd.write(python_script)

--- a/tests/test_script_to_cmd.py
+++ b/tests/test_script_to_cmd.py
@@ -48,7 +48,7 @@ def test_should_get_dvc_param_from_docstring():
 
 
 def test_should_get_dvc_meta_default_filen_name():
-    """Test ge tdvc default meta file name"""
+    """Test get dvc default meta file name"""
     docstring_info = DocstringInfo(method_name='my_method',
                                    docstring=dc_parse(''),
                                    repr='',
@@ -60,7 +60,7 @@ def test_should_get_dvc_meta_default_filen_name():
 
 
 def test_should_get_dvc_cmd_param_from_docstring():
-    """Test dvc parameters are extracted from docstring"""
+    """Test dvc cmd parameter is extracted from docstring"""
     cmd = 'dvc run -o ./out_train.csv \n' \
           '-o ./out_test.csv\n' \
           './py_cmd -m train --out ./out_train.csv &&\n' \


### PR DESCRIPTION
Be able to use Jinja variable in DVC Docstring part. Those variables are replaced in DVC step generation (command gen_dvc)
