### PR TITLE
#DC - 135 Report error if a Jinja template variable is missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,8 @@ This document describes changes between each past release.
 
 0.0.10 (not yet)
 ----------------
--
+- Remove trailing cells
+- Report an error if a Jinja template variable is missing (write template and docstring resolution)
 
 0.0.9 (2019-01-03)
 ----------------

--- a/mlvtools/cmd.py
+++ b/mlvtools/cmd.py
@@ -35,8 +35,7 @@ class CommandHelper:
             self.run(*args, **kwargs)
         except MlVToolException as e:
             logging.critical(e)
-            if e.__cause__:
-                logging.debug(traceback.print_tb(e.__cause__))
+            logging.debug(traceback.format_exc())
         except Exception as e:
             logging.critical(f'Unexpected error happened: {e}')
             logging.info('Reason: ', exc_info=True)

--- a/mlvtools/docstring_helpers/parse.py
+++ b/mlvtools/docstring_helpers/parse.py
@@ -6,6 +6,7 @@ from docstring_parser import parse as dc_parse
 from docstring_parser.parser import Docstring, ParseError
 
 from mlvtools.exception import MlVToolException
+from mlvtools.helper import render_string_template
 
 
 class DocstringDvc:
@@ -196,6 +197,6 @@ def resolve_docstring(docstring: str, docstring_conf: dict) -> str:
         Use jinja to resolve docstring template using user custom configuration
     """
     try:
-        return jinja2.Environment().from_string(docstring).render(conf=docstring_conf)
+        return render_string_template(docstring, conf=docstring_conf)
     except jinja2.exceptions.TemplateError as e:
         raise MlVToolException(f'Cannot resolve docstring using Jinja, {e}') from e

--- a/mlvtools/exception.py
+++ b/mlvtools/exception.py
@@ -1,8 +1,6 @@
 class MlVToolException(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
-class MlVToolConfException(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+class MlVToolConfException(MlVToolException):
+    pass

--- a/mlvtools/gen_dvc.py
+++ b/mlvtools/gen_dvc.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import argparse
 import logging
 from os.path import realpath, dirname
 from os.path import relpath, join, basename
+
+import argparse
 from typing import List
 
 from mlvtools.cmd import CommandHelper, ArgumentBuilder
@@ -29,7 +30,12 @@ def get_dvc_template_data(docstring_info: DocstringInfo, python_cmd_path: str, m
     info = {
         'variables': variables,
         'meta_file_name_var_assign': f'{meta_file_variable_name}="{meta_file_name}"',
-        'meta_file_name_var': meta_file_variable_name
+        'meta_file_name_var': meta_file_variable_name,
+        'whole_command': None,
+        'python_script': python_cmd_path,
+        'dvc_inputs': [],
+        'dvc_outputs': [],
+        'python_params': ''
     }
 
     if dvc_params.dvc_cmd:
@@ -37,11 +43,8 @@ def get_dvc_template_data(docstring_info: DocstringInfo, python_cmd_path: str, m
         info['whole_command'] = dvc_params.dvc_cmd.cmd.replace('\n', ' \\\n')
         logging.debug(f'Custom command {info["whole_command"]}')
         return info
+
     logging.info('DVC mode: generate command from parameters')
-    # keep meta file name default value if not specified
-    info['python_script'] = python_cmd_path
-    info['dvc_inputs'] = []
-    info['dvc_outputs'] = []
     python_params = []
 
     def handle_params(dvc_docstring_params: List[DocstringDvc], label: str):

--- a/tests/unit/test_script_to_cmd.py
+++ b/tests/unit/test_script_to_cmd.py
@@ -34,7 +34,9 @@ def test_should_get_dvc_param_from_docstring():
         'python_params': '--param2 $PARAM2 --param-one $PARAM_ONE --train --rate 12',
         'python_script': python_cmd_path,
         'meta_file_name_var_assign': 'MLV_META="Pipeline1.dvc"',
-        'meta_file_name_var': 'MLV_META'
+        'meta_file_name_var': 'MLV_META',
+        'whole_command': None,
+
     }
     assert expected_info.keys() == info.keys()
 
@@ -75,6 +77,5 @@ def test_should_get_dvc_cmd_param_from_docstring():
     python_cmd_path = '../script/python/test_cmd'
     info = get_dvc_template_data(docstring_info, python_cmd_path, meta_file_variable_name='MLV_META')
 
-    assert len(info.keys()) == 4
     assert info['whole_command'] == cmd.replace('\n', ' \\\n')
     assert not info['variables']


### PR DESCRIPTION
For all Jinja template usage in this project an exception is raised if an undefined variable is used (print/iterate/other access as specified in Jinja).

It is now impossible to generate a DVC command with a variable used in the docstring but not defined in the docstring configuration. This is done to avoid to silently generate an invalid script.

 - Improve exception handling
 - Raise if a template variable is undefined with StrictUndefined behavior
- Factorize write template and resolve docstring templating
