### PR TITLE
Refs #DC-145 Add an option to force run without cache in DVC generate…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This document describes changes between each past release.
 ----------------
 - Remove trailing cells
 - Report an error if a Jinja template variable is missing (write template and docstring resolution)
+- Add a no-cache option to generated DVC commands
 
 0.0.9 (2019-01-03)
 ----------------

--- a/template/dvc-cmd.tpl
+++ b/template/dvc-cmd.tpl
@@ -1,12 +1,35 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
+usage() { echo "$0 usage:" && grep " .*)\ #" $0; exit 0; }
+NO_CACHE_OPT=''
+options=$(getopt -l "help,no-cache" -o "h" -a -- "$@")
+eval set -- "$options"
+
+while true; do
+    case $1 in
+        -h|--help) # Display help
+            usage
+            ;;
+        --no-cache) # Disable cache
+            NO_CACHE_OPT=' --ignore-build-cache'
+        ;;
+        --)
+            shift
+            break;;
+    esac
+    shift
+done
+
+
+
 pushd "$(git rev-parse --show-toplevel)"
+set -x
 {% for variable in info.variables -%}
     {{ variable }}
 {% endfor %}
 # META FILENAME, MODIFY IF DUPLICATE
 {{ info.meta_file_name_var_assign }}
 {% if not info.whole_command %}
-dvc run -f ${{info.meta_file_name_var}} \
+dvc run${NO_CACHE_OPT} -f ${{info.meta_file_name_var}} \
 {% for dep in info.dvc_inputs -%}
     -d {{ dep }} \
 {% endfor -%}

--- a/tests/functional/gen_dvc/test_generated_content.py
+++ b/tests/functional/gen_dvc/test_generated_content.py
@@ -50,7 +50,7 @@ def test_should_generate_commands(work_dir):
 
     assert 'OUTPUT_FILE="./data/other.txt"' in dvc_bash_content
     assert 'MLV_DVC_META_FILENAME="script_python.dvc"' in dvc_bash_content
-    assert 'dvc run -f $MLV_DVC_META_FILENAME' in dvc_bash_content
+    assert 'dvc run${NO_CACHE_OPT} -f $MLV_DVC_META_FILENAME' in dvc_bash_content
     assert '-o $OUTPUT_FILE' in dvc_bash_content
     assert '-o ./data/other.txt' in dvc_bash_content
     assert '-d $INPUT_FILE' in dvc_bash_content

--- a/tests/large/gen_dvc/data/script.py
+++ b/tests/large/gen_dvc/data/script.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python3
+#!/usr/bin/env python3
 # Generated from ./tests/large/ipynb_to_python/data/notebook.ipynb
 import argparse
 

--- a/tests/large/gen_dvc/data/write_name.py
+++ b/tests/large/gen_dvc/data/write_name.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import argparse
+from os.path import exists
+
+
+def mlvtools_write_hello_in_file(output_file: str, name: str):
+    """
+    :param str output_file: path to the output file
+    :param str name: your name
+    :dvc-out output_file: {{conf.output_file}}
+    :dvc-extra: --name {{conf.name}}
+    """
+    first_run = not exists(output_file)
+    with open(output_file, 'w') as fd:
+        suffix = 'First run' if first_run else 'Not the first run'
+        fd.write(f'Hello {name}! {suffix}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Command for script mlvtools_write_hello_in_file')
+    parser.add_argument('--output-file', type=str,
+                        required=True, help="path to the output file")
+    parser.add_argument('--name', type=str,
+                        required=True, help="your name")
+    args = parser.parse_args()
+
+    mlvtools_write_hello_in_file(args.output_file, args.name)

--- a/tests/large/gen_dvc/test_gen_dvc.py
+++ b/tests/large/gen_dvc/test_gen_dvc.py
@@ -3,6 +3,8 @@ from os import stat as os_stat
 from os.path import dirname, join, exists
 from subprocess import check_call
 
+import yaml
+
 CURRENT_DIR = dirname(__file__)
 
 
@@ -16,3 +18,53 @@ def test_should_gen_dvc_command_using_command_line(work_dir):
 
     assert exists(out_dvc_path)
     assert stat.S_IMODE(os_stat(out_dvc_path).st_mode) == 0o755
+
+
+def test_dvc_command_cache_can_be_disabled(work_dir):
+    """
+        Test a generated dvc command can be re-run without cache
+        - Create a DVC command using gen_dvc and a docstring conf
+            This command call through DVC a 'write_name.py' script.
+            The output of this script is tracked by DVC.
+            This script has a side effect (which is bad), it does not write the
+            same thing in the output even without input change (it is done for test purpose)
+        - Initialize a Git/DVC environment
+        - Run the generated DVC command
+        - Re-run using cache and check nothing has changed
+        - Re-run without cache and check output content has changed (which means the associated script
+        is really re-run and the side effect can happen)
+    """
+
+    # Write DVC command docstring conf to specify output_file and name
+    docstring_conf_file = join(work_dir, 'docstring.conf')
+    output_file = join(work_dir, 'test.out')
+    with open(docstring_conf_file, 'w') as fd:
+        yaml.dump({'output_file': output_file,
+                   'name': 'Bob'},
+                  fd)
+
+    # Generate DVC command for write_name.py script
+    script_path = join(CURRENT_DIR, 'data', 'write_name.py')
+    dvc_cmd = join(work_dir, 'dvc_cmd')
+    check_call(['gen_dvc', '-i', script_path, '-o', dvc_cmd, '-w', work_dir, '--docstring-conf', docstring_conf_file])
+
+    # Run the DVC command once
+    check_call(['git', 'init'], cwd=work_dir)
+    check_call(['dvc', 'init'], cwd=work_dir)
+
+    check_call(dvc_cmd, cwd=work_dir)
+    assert exists(output_file)
+    with open(output_file) as fd:
+        assert fd.read() == 'Hello Bob! First run'
+
+    # Re-run using cache then assert nothing as changed
+    check_call(dvc_cmd, cwd=work_dir)
+    assert exists(output_file)
+    with open(output_file) as fd:
+        assert fd.read() == 'Hello Bob! First run'
+
+    # Re-run without cache then assert side effect happened
+    check_call([f'yes | {dvc_cmd} --no-cache'], shell=True, cwd=work_dir)
+    assert exists(output_file)
+    with open(output_file) as fd:
+        assert fd.read() == 'Hello Bob! Not the first run'

--- a/tests/large/run/large_tests.sh
+++ b/tests/large/run/large_tests.sh
@@ -6,6 +6,6 @@ popd
 
 pushd /tmp
 export PATH=$PATH:$HOME/.local/bin
-pip install --user $GIT_DIR/package/ml_versioning_tools-*.whl pytest
-pytest $GIT_DIR/tests/large
+pip install --user $GIT_DIR/package/ml_versioning_tools-*.whl pytest dvc
+pytest -s $GIT_DIR/tests/large
 popd


### PR DESCRIPTION
Be able to run a generated DVC command without cache:
add a --no-cache option to disable cache check.
(ex: ./pipeline/dvc/mlvtools_006_cnn_training_dvc --no-cache)