### PR TITLE
Fix gen_dvc tests to account for new DVC behaviour

### DIFF
--- a/tests/large/gen_dvc/data/write_name.py
+++ b/tests/large/gen_dvc/data/write_name.py
@@ -3,10 +3,12 @@ import argparse
 from os.path import exists, join, dirname
 
 
-def mlvtools_write_hello_in_file(output_file: str, name: str):
+def mlvtools_write_hello_in_file(input_file: str, output_file: str, name: str):
     """
+    :param str input_file: path to the input file
     :param str output_file: path to the output file
     :param str name: your name
+    :dvc-in input_file: {{conf.input_file}}
     :dvc-out output_file: {{conf.output_file}}
     :dvc-extra: --name {{conf.name}}
     """
@@ -23,10 +25,12 @@ def mlvtools_write_hello_in_file(output_file: str, name: str):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Command for script mlvtools_write_hello_in_file')
+    parser.add_argument('--input-file', type=str,
+                        required=True, help="path to the input file")
     parser.add_argument('--output-file', type=str,
                         required=True, help="path to the output file")
     parser.add_argument('--name', type=str,
                         required=True, help="your name")
     args = parser.parse_args()
 
-    mlvtools_write_hello_in_file(args.output_file, args.name)
+    mlvtools_write_hello_in_file(args.input_file, args.output_file, args.name)

--- a/tests/large/gen_dvc/test_gen_dvc.py
+++ b/tests/large/gen_dvc/test_gen_dvc.py
@@ -1,6 +1,8 @@
 import stat
 import os
 
+from pathlib import Path
+
 import pytest
 import yaml
 from subprocess import check_call
@@ -44,9 +46,6 @@ def test_should_generate_dvc_command_even_if_sub_dir_exists(work_dir, output_pat
     assert os.path.exists(output_path)
 
 
-@pytest.mark.xfail(strict=True,
-                   reason='DVC behaviour changed, cache is not working correctly'
-                          '(see //github.com/iterative/dvc/issues/2843)')
 def test_dvc_command_cache_can_be_disabled(work_dir):
     """
         Test a generated dvc command can be re-run without cache
@@ -64,11 +63,15 @@ def test_dvc_command_cache_can_be_disabled(work_dir):
 
     # Write DVC command docstring conf to specify output_file and name
     docstring_conf_file = os.path.join(work_dir, 'docstring.conf')
+    input_file = os.path.join(work_dir, 'input')
     output_file = os.path.join(work_dir, 'test.out')
+    Path(input_file).touch()
     with open(docstring_conf_file, 'w') as fd:
-        yaml.dump({'output_file': output_file,
-                   'name': 'Bob'},
-                  fd)
+        yaml.dump({
+            'input_file': input_file,
+            'output_file': output_file,
+            'name': 'Bob'},
+            fd)
 
     # Generate DVC command for write_name.py script
     script_path = os.path.join(CURRENT_DIR, 'data', 'write_name.py')


### PR DESCRIPTION
Steps without dependency are no longer cached by DVC