### PR TITLE
Pushd to the working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The **{related_param}** is a parameter of the corresponding **Python 3** script,
 The **dvc-extra** allows to declare parameters which are not dvc outputs or dependencies.
 Those parameters are provided to the call of the **Python 3** command.
  
-    pushd $(git rev-parse --show-toplevel)
+    pushd /working-directory
     
     INPUT_CSV_FILE="./data/info.csv"
     OUTPUT_CSV_FILE="./data/test_set.csv"
@@ -254,7 +254,7 @@ The variables $MLV_PY_CMD_PATH and $MLV_PY_CMD_NAME are available. They respecti
  of the corresponding python command.
 The variable $MLV_DVC_META_FILENAME contains the default name of the **DVC** meta file.
  
-    pushd $(git rev-parse --show-toplevel)
+    pushd /working-directory
     MLV_PY_CMD_PATH="gen_src/python_script.py"
     MLV_PY_CMD_NAME="python_script.py"
         

--- a/mlvtools/gen_dvc.py
+++ b/mlvtools/gen_dvc.py
@@ -17,7 +17,8 @@ CURRENT_DIR = realpath(dirname(__file__))
 DVC_CMD_TEMPLATE_NAME = 'dvc-cmd.tpl'
 
 
-def get_dvc_template_data(docstring_info: DocstringInfo, python_cmd_path: str, meta_file_variable_name: str,
+def get_dvc_template_data(docstring_info: DocstringInfo, working_directory: str,
+                          python_cmd_path: str, meta_file_variable_name: str,
                           meta_file_root_dir_path: str, extra_variables: dict = None):
     """
         Format data from docstring for dvc bash command template
@@ -34,6 +35,7 @@ def get_dvc_template_data(docstring_info: DocstringInfo, python_cmd_path: str, m
         'meta_file_name_var': meta_file_variable_name,
         'whole_command': None,
         'python_script': python_cmd_path,
+        'working_directory': working_directory,
         'dvc_inputs': [],
         'dvc_outputs': [],
         'python_params': ''
@@ -80,6 +82,7 @@ def gen_dvc_command(input_path: str, dvc_output_path: str, conf: MlVToolConf, do
     extra_var = {conf.dvc_var_python_cmd_path: python_cmd_rel_path,
                  conf.dvc_var_python_cmd_name: basename(python_cmd_rel_path)}
     info = get_dvc_template_data(docstring_info,
+                                 conf.top_directory,
                                  python_cmd_rel_path,
                                  conf.dvc_var_meta_filename,
                                  conf.path.dvc_metadata_root_dir if conf.path else '',

--- a/template/dvc-cmd.tpl
+++ b/template/dvc-cmd.tpl
@@ -21,7 +21,7 @@ done
 
 
 
-pushd "$(git rev-parse --show-toplevel)"
+pushd "{{ info.working_directory }}"
 set -x
 {% for variable in info.variables -%}
     {{ variable }}

--- a/tests/large/gen_dvc/test_gen_dvc.py
+++ b/tests/large/gen_dvc/test_gen_dvc.py
@@ -46,6 +46,20 @@ def test_should_generate_dvc_command_even_if_sub_dir_exists(work_dir, output_pat
     assert os.path.exists(output_path)
 
 
+def test_dvc_command_change_to_correct_working_directory(work_dir):
+    """
+        Test that the dvc command generates a script that changes to the correct working directory
+    """
+    script_path = os.path.join(CURRENT_DIR, 'data', 'script.py')
+    output_path = 'out_dvc'
+    check_call(['gen_dvc', '-i', script_path, '-o', output_path, '-w', work_dir], cwd=work_dir)
+
+    output_path = os.path.join(work_dir, output_path)
+    assert os.path.exists(output_path)
+    with open(output_path) as f:
+        assert 'pushd "{}"'.format(work_dir) in f.read()
+
+
 def test_dvc_command_cache_can_be_disabled(work_dir):
     """
         Test a generated dvc command can be re-run without cache

--- a/tests/unit/test_script_to_cmd.py
+++ b/tests/unit/test_script_to_cmd.py
@@ -21,9 +21,10 @@ def test_should_get_dvc_param_from_docstring():
                                    docstring=dc_parse(repr),
                                    repr=repr,
                                    file_path='/data/my_prj/python/my_file.py')
+    working_directory = '/some/working/directory'
     python_cmd_path = '/script/python/test_cmd'
     extra_var = {'MLV_PY_CMD_PATH': python_cmd_path, 'MLV_PY_CMD_NAME': basename(python_cmd_path)}
-    info = get_dvc_template_data(docstring_info, python_cmd_path, meta_file_variable_name='MLV_META',
+    info = get_dvc_template_data(docstring_info, working_directory, python_cmd_path, meta_file_variable_name='MLV_META',
                                  meta_file_root_dir_path='some/path', extra_variables=extra_var)
 
     expected_info = {
@@ -32,6 +33,7 @@ def test_should_get_dvc_param_from_docstring():
         'dvc_inputs': ['$PARAM2', 'path/to/other/infile.test'],
         'dvc_outputs': ['path/to/file.txt', '$PARAM_ONE'],
         'python_params': '--param2 $PARAM2 --param-one $PARAM_ONE --train --rate 12',
+        'working_directory': '/some/working/directory',
         'python_script': python_cmd_path,
         'meta_file_name_var_assign': 'MLV_META="some/path/Pipeline1.dvc"',
         'meta_file_name_var': 'MLV_META',
@@ -55,9 +57,11 @@ def test_should_get_dvc_meta_default_file_name():
                                    docstring=dc_parse(''),
                                    repr='',
                                    file_path='/data/my_prj/python/my_file.ipynb')
+    working_directory = '/some/working/directory'
     python_cmd_path = '/script/python/test_cmd.py'
     info = get_dvc_template_data(
         docstring_info,
+        working_directory,
         python_cmd_path,
         meta_file_variable_name='MLV_META',
         meta_file_root_dir_path='some/path'
@@ -79,9 +83,11 @@ def test_should_get_dvc_cmd_param_from_docstring():
                                    docstring=dc_parse(repr),
                                    repr=repr,
                                    file_path='/data/my_prj/python/my_file.py')
+    working_directory = '/some/working/directory'
     python_cmd_path = '../script/python/test_cmd'
     info = get_dvc_template_data(
         docstring_info,
+        working_directory,
         python_cmd_path,
         meta_file_variable_name='MLV_META',
         meta_file_root_dir_path='some/path'


### PR DESCRIPTION
With this gen_dvc generated scripts now change to the actual working directory instead of the Git root directory.

The working directory may be the Git root directory, but that's not always the case.

Closes #60.