### PR TITLE
Do not use typing in generated Python scripts

### DIFF
--- a/mlvtools/ipynb_to_python.py
+++ b/mlvtools/ipynb_to_python.py
@@ -100,9 +100,7 @@ def get_param_as_python_method_format(docstring_data: Docstring) -> str:
     """
         Extract parameters from a docstring then format them
     """
-    params = ['{}{}'.format(p.arg_name, '' if not p.type_name else f': {p.type_name}')
-              for p in docstring_data.params]
-    return ', '.join(params)
+    return ', '.join(f'{p.arg_name}' for p in docstring_data.params)
 
 
 def get_docstring_data(cell_content: str) -> Tuple[Docstring, str]:

--- a/mlvtools/templates/ml-python.tpl
+++ b/mlvtools/templates/ml-python.tpl
@@ -2,7 +2,6 @@
 {% if 'metadata' in resources -%}
 # Generated from {{ resources['metadata'].get('path') }}/{{ resources['metadata'].get('name') }}.ipynb
 {%- endif %}
-from typing import List
 import argparse
 {# Write main function with optional parameters and docstring #}
 {%- set func_name = resources.get('metadata', {'name': 'input_func'}).get('name') | sanitize_method_name -%}

--- a/tests/functional/check_all_script_consistency/test_content_consistency.py
+++ b/tests/functional/check_all_script_consistency/test_content_consistency.py
@@ -30,7 +30,6 @@ def write_script(path: str, content: str):
     name = basename(path).replace('.py', '')
     script_content = f'''
 #!/usr/bin/env python3
-from typing import List
 import argparse
 def {name}():
     {content}

--- a/tests/functional/check_script_consistency/test_content_consistency.py
+++ b/tests/functional/check_script_consistency/test_content_consistency.py
@@ -21,7 +21,6 @@ def ref_notebook_path(work_dir):
 def ref_script_content():
     return '''
 #!/usr/bin/env python3
-from typing import List
 import argparse
 def mlvtools_test():
     print('poney')

--- a/tests/functional/gen_dvc/test_generated_content.py
+++ b/tests/functional/gen_dvc/test_generated_content.py
@@ -14,7 +14,7 @@ def test_should_generate_commands(work_dir):
         Test dvc bash command is generated from python script with param specified
         in docstring.
     """
-    python_script = 'def my_funct(subset: str, rate: int):\n' \
+    python_script = 'def my_funct(subset, rate):\n' \
                     '\t"""\n' \
                     ':param str input_file: the input file\n' \
                     ':param output_file: the output_file\n' \

--- a/tests/functional/ipynb_to_python/test_generated_content.py
+++ b/tests/functional/ipynb_to_python/test_generated_content.py
@@ -102,7 +102,7 @@ def test_should_generate_python_script_no_conf(work_dir):
         file_content = fd.read()
 
     check_content(docstring, kept_cells, dropped_cells, file_content)
-    assert 'def mlvtools_test_nb(subset: str, rate: int):' in file_content
+    assert 'def mlvtools_test_nb(subset, rate):' in file_content
     assert 'mlvtools_test_nb(args.subset, args.rate)' in file_content
 
     # Ensure generated file syntax is right

--- a/tests/large/check_consistency/data/script_dir/mlvtools_notebook.py
+++ b/tests/large/check_consistency/data/script_dir/mlvtools_notebook.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 # Generated from ./notebooks/notebook.ipynb
-from typing import List
 import argparse
 
 
-def mlvtools_notebook(sanitized_data: str, octal_data: str, binary_data: str, size_bin_data: int):
+def mlvtools_notebook(sanitized_data, octal_data, binary_data, size_bin_data):
     """
     :param str sanitized_data: path to input sanitized data
     :param str octal_data: path to octal data output file

--- a/tests/large/check_consistency/data/script_dir/mlvtools_notebook_blank_and_comment_diff.py
+++ b/tests/large/check_consistency/data/script_dir/mlvtools_notebook_blank_and_comment_diff.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # Generated from ./notebook_blank_and_comment_diff.ipynb
-from typing import List
 import argparse
-def mlvtools_notebook_blank_and_comment_diff(name: str):
+def mlvtools_notebook_blank_and_comment_diff(name):
     """
     :param str name: your name
     """

--- a/tests/large/check_consistency/data/script_dir/mlvtools_notebook_exactly_the_same.py
+++ b/tests/large/check_consistency/data/script_dir/mlvtools_notebook_exactly_the_same.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 # Generated from ./notebooks/notebook_exactly_the_same.ipynb
-from typing import List
 import argparse
 
 
-def mlvtools_notebook_exactly_the_same(year: str):
+def mlvtools_notebook_exactly_the_same(year):
     """
     :param str year: your age
     """

--- a/tests/large/check_consistency/data/script_no_blank_no_comment.py
+++ b/tests/large/check_consistency/data/script_no_blank_no_comment.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-from typing import List
 import argparse
-def mlvtools_notebook_blank_and_comment_diff(name: str):
+def mlvtools_notebook_blank_and_comment_diff(name):
     """
     :param str name: your name
     """

--- a/tests/large/check_consistency/data/script_no_blank_no_comment_disable_cell.py
+++ b/tests/large/check_consistency/data/script_no_blank_no_comment_disable_cell.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-from typing import List
 import argparse
-def mlvtools_notebook_blank_and_comment_diff(name: str):
+def mlvtools_notebook_blank_and_comment_diff(name):
     """
     :param str name: your name
     """

--- a/tests/unit/test_check_consitency.py
+++ b/tests/unit/test_check_consitency.py
@@ -50,7 +50,6 @@ def test_should_find_consistency_between_notebook_and_script_with_diff_empty_lin
                                                  '  print("hello")\n')])
     script_content = '''
 #!/usr/bin/env python3
-from typing import List
 import argparse
 def mlvtools_test():
     print('poney')

--- a/tests/unit/test_convert_from_notebook.py
+++ b/tests/unit/test_convert_from_notebook.py
@@ -66,7 +66,7 @@ toto = 12
         content = fd.read()
 
     # Check main method is created
-    assert 'def mlvtools_test(subset: str, rate: int, param3):' in content
+    assert 'def mlvtools_test(subset, rate, param3):' in content
 
 
 def test_should_raise_if_invalid_docstring(conf, work_dir):
@@ -141,7 +141,7 @@ def test_should_extract_parameters_as_python_params():
     """'''
     parameters = get_param_as_python_method_format(parse_docstring(docstring_str))
 
-    assert parameters == 'param_one: str, param2: int, param3, param4'
+    assert parameters == 'param_one, param2, param3, param4'
 
 
 def test_should_extract_parameters_as_python_command_line_arguments():
@@ -268,7 +268,7 @@ code = 'some code again'
         }
     ]
 
-    assert docstring_wrapper.params == 'param_one: str, param2: int, param3, param4'
+    assert docstring_wrapper.params == 'param_one, param2, param3, param4'
     assert docstring_wrapper.docstring == docstring.strip('\n')
     assert docstring_wrapper.arguments == expected_arguments
     assert docstring_wrapper.arg_params == 'args.param_one, args.param2, args.param3, args.param4'


### PR DESCRIPTION
When the generated function has no `List` arguments the generated Python script includes an unnecessary `from typing import List`.

This PR completely removes type annotations from the generated Python scripts.