### PR TITLE
Add dvc to dev requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ dev =
     pytest-cov
     pytest-mock
     twine
+    dvc
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Needed for `tests/large/gen_dvc/test_gen_dvc.py::test_dvc_command_cache_can_be_disabled`