### PR TITLE
Fix yaml deprecation warnings

### DIFF
--- a/mlvtools/conf/conf.py
+++ b/mlvtools/conf/conf.py
@@ -117,7 +117,7 @@ def load_docstring_conf(docstring_conf_path: str) -> dict:
     try:
         logging.info(f'Load docstring configuration from {docstring_conf_path}')
         with open(docstring_conf_path, 'r') as fd:
-            return yaml.load(fd)
+            return yaml.safe_load(fd)
     except yaml.YAMLError as e:
         raise MlVToolConfException(f'Cannot load docstring conf {docstring_conf_path}. Format error {e}.') from e
     except IOError as e:

--- a/mlvtools/mlv_dvc/dvc_parser.py
+++ b/mlvtools/mlv_dvc/dvc_parser.py
@@ -18,7 +18,7 @@ def get_dvc_meta(dvc_meta_file: str) -> DvcMeta:
     logging.debug(f'Get DVC meta from {dvc_meta_file}')
     try:
         with open(dvc_meta_file, 'r') as fd:
-            raw_data = yaml.load(fd.read())
+            raw_data = yaml.safe_load(fd.read())
             deps = [v['path'] for v in raw_data.get('deps', [])]
             outs = [v['path'] for v in raw_data.get('outs', [])]
             meta = DvcMeta(basename(dvc_meta_file), raw_data.get('cmd', ''), deps, outs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ dev =
     pytest-cov
     pytest-mock
     twine
+    dvc
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
How to test : 

` pytest -s tests/ 2>&1 | grep YAMLLoadWarning ` should return nothing