### PR TITLE
Make --working-directory default to the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ is used to declare metadata such as parameters, dvc inputs/outputs, etc.
 
 `Working Directory`: the project's working directory. Files specified in the
 user configuration are relative to this directory. The `--working-directory`
-(or `-w`) flag is used to specify the Working Directory.
+(or `-w`) flag is used to specify the Working Directory. If not specified
+the current directory is used.
 
 ## Tools
 

--- a/mlvtools/cmd.py
+++ b/mlvtools/cmd.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import traceback
-from os.path import exists
+import os.path
 
 import argparse
 from argparse import ArgumentParser, Namespace
@@ -30,7 +30,7 @@ class CommandHelper:
         if force:
             return
         for output in outputs:
-            if exists(output):
+            if os.path.exists(output):
                 raise MlVToolException(f'Output file {output} already exists, '
                                        f'use --force option to overwrite it')
 
@@ -59,8 +59,9 @@ class ArgumentBuilder:
         self.parser = ArgumentParser(**kwargs)
 
     def add_work_dir_argument(self) -> 'ArgumentBuilder':
-        self.parser.add_argument('-w', '--working-directory', type=str, required=True,
-                                 help='Working directory. Other paths are relative to the working directory.')
+        self.parser.add_argument('-w', '--working-directory', type=str, default=os.path.curdir,
+                                 help='Working directory. Other paths are relative to the '
+                                      'working directory. Defaults to the current directory.')
         return self
 
     def add_conf_path_argument(self) -> 'ArgumentBuilder':


### PR DESCRIPTION
With https://github.com/peopledoc/mlvtools/pull/64 we made it mandatory to specify the working directory on the command line. Before that change the working directory defaulted to the Git repository's top directory. We created #64 to completely decouple mlvtools from Git.

This PR makes `--working-directory` optional again. But instead of defaulting to the Git repository's top directory, it defaults to the current directory (`.` on Windows and POSIX).

Closes #81.